### PR TITLE
Update:  Resource Manager disk cache 

### DIFF
--- a/core/src/main/java/io/blockv/core/client/Blockv.kt
+++ b/core/src/main/java/io/blockv/core/client/Blockv.kt
@@ -85,6 +85,7 @@ class Blockv {
   }
 
   private val cacheDir: File
+  private val fileDir: File
 
   @Volatile
   private var internalFaceManager: FaceManager? = null
@@ -190,6 +191,7 @@ class Blockv {
 
   constructor(context: Context, appId: String, redirectUri: String) {
     this.cacheDir = context.cacheDir
+    this.fileDir = context.filesDir
     this.jsonModule = JsonModule()
     this.appId = appId
     this.preferences = Preferences(context, jsonModule)
@@ -199,7 +201,7 @@ class Blockv {
       appId,
       redirectUri
     )
-    this.resourceManager = ResourceManagerImpl(cacheDir, ResourceEncoderImpl(preferences), preferences)
+    this.resourceManager = ResourceManagerImpl(cacheDir, fileDir, ResourceEncoderImpl(preferences), preferences)
     this.auth = AuthenticatorImpl(this.preferences, jsonModule)
     this.netModule = NetModule(
       auth,
@@ -229,11 +231,12 @@ class Blockv {
 
   constructor(context: Context, environment: Environment) {
     this.cacheDir = context.cacheDir
+    this.fileDir = context.filesDir
     this.jsonModule = JsonModule()
     this.appId = environment.appId
     this.preferences = Preferences(context, jsonModule)
     this.preferences.environment = environment
-    this.resourceManager = ResourceManagerImpl(cacheDir, ResourceEncoderImpl(preferences), preferences)
+    this.resourceManager = ResourceManagerImpl(cacheDir,fileDir, ResourceEncoderImpl(preferences), preferences)
     this.auth = AuthenticatorImpl(this.preferences, jsonModule)
     this.netModule = NetModule(auth, preferences, jsonModule)
     val websocket = WebsocketImpl(preferences, jsonModule, auth)
@@ -272,6 +275,7 @@ class Blockv {
     appManager: AppManager
   ) {
     this.cacheDir = context.cacheDir
+    this.fileDir = context.filesDir
     this.appId = appId
     this.preferences = preferences
     this.preferences.environment = Environment(


### PR DESCRIPTION
Update the disk cache to use both the cache directory and file directory. 
Store smaller files and current download's in the file's directory so the system won't remove them. Files that are either bigger than a 20th of the cache size or are remove by the LruCache are put into the cache directory, where system can remove them when needed.